### PR TITLE
feat: setup ESLint and Prettier with type safety improvements

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,8 @@
+{
+  "semi": true,
+  "trailingComma": "es5",
+  "singleQuote": true,
+  "printWidth": 80,
+  "tabWidth": 2,
+  "useTabs": false
+}

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -3,12 +3,37 @@
  */
 
 import { z } from 'zod';
+import {
+  APIGatewayProxyEvent,
+  APIGatewayProxyResult,
+  Context,
+} from 'aws-lambda';
 
+// Core Types
 export interface MCPServerConfig {
   name: string;
   version: string;
   description?: string;
   protocolVersion?: string;
+}
+
+// JSON-RPC Types
+export interface JsonRpcRequest {
+  jsonrpc: string;
+  method: string;
+  params?: Record<string, unknown>;
+  id?: string | number | null;
+}
+
+export interface JsonRpcResponse {
+  jsonrpc: string;
+  result?: unknown;
+  error?: {
+    code: number;
+    message: string;
+    data?: unknown;
+  };
+  id?: string | number | null;
 }
 
 export interface MCPToolResult {
@@ -42,34 +67,59 @@ export interface MCPPromptResult {
   }>;
 }
 
+// Authentication Types
+export interface AuthUser {
+  token?: string;
+  [key: string]: unknown;
+}
+
+export interface AuthValidationResult {
+  isValid: boolean;
+  user?: AuthUser;
+  token?: string;
+  error?: APIGatewayProxyResult;
+}
+
+export interface BearerTokenAuthConfig {
+  type: 'bearer-token';
+  tokens?: string[];
+  validate?: (
+    token: string,
+    event: APIGatewayProxyEvent
+  ) => AuthValidationResult | Promise<AuthValidationResult>;
+}
+
+export type AuthConfig = BearerTokenAuthConfig;
+
+export interface LambdaHandlerOptions {
+  auth?: AuthConfig;
+}
+
+// Schema Types
 export type ZodSchema = Record<string, z.ZodType>;
-
-export type ToolHandler<T = any> = (args: T) => Promise<MCPToolResult>;
+export type ToolHandler<T = Record<string, unknown>> = (args: T) => Promise<MCPToolResult>;
 export type ResourceHandler = (uri: string) => Promise<MCPResourceResult>;
-export type PromptHandler<T = any> = (args: T) => Promise<MCPPromptResult>;
+export type PromptHandler<T = Record<string, unknown>> = (args: T) => Promise<MCPPromptResult>;
 
+// Core Classes
 export declare class MCPServer {
   constructor(config: MCPServerConfig);
-  
+
   tool<T extends ZodSchema>(
     name: string,
     inputSchema: T,
     handler: ToolHandler<z.infer<z.ZodObject<T>>>
   ): MCPServer;
-  
-  resource(
-    name: string,
-    uri: string,
-    handler: ResourceHandler
-  ): MCPServer;
-  
+
+  resource(name: string, uri: string, handler: ResourceHandler): MCPServer;
+
   prompt<T extends ZodSchema>(
     name: string,
     inputSchema: T,
     handler: PromptHandler<z.infer<z.ZodObject<T>>>
   ): MCPServer;
-  
-  handleRequest(request: any): Promise<any>;
+
+  handleRequest(request: JsonRpcRequest): Promise<JsonRpcResponse | null>;
   getStats(): {
     tools: number;
     resources: number;
@@ -78,31 +128,18 @@ export declare class MCPServer {
   };
 }
 
-export interface AWSLambdaEvent {
-  httpMethod: string;
-  headers: Record<string, string>;
-  body: string;
-}
-
-export interface AWSLambdaContext {
-  // AWS Lambda context properties
-}
-
-export interface AWSLambdaResponse {
-  statusCode: number;
-  headers: Record<string, string>;
-  body: string;
-}
-
-export type LambdaHandler = (
-  event: AWSLambdaEvent,
-  context: AWSLambdaContext
-) => Promise<AWSLambdaResponse>;
-
-export declare function createLambdaHandler(mcpServer: MCPServer): LambdaHandler;
-
+// Main Functions
 export declare function createMCPServer(config: MCPServerConfig): MCPServer;
 
+export declare function createLambdaHandler(
+  mcpServer: MCPServer,
+  options?: LambdaHandlerOptions
+): (
+  event: APIGatewayProxyEvent,
+  context: Context
+) => Promise<APIGatewayProxyResult>;
+
+// Common Schemas
 export declare const CommonSchemas: {
   string: z.ZodString;
   number: z.ZodNumber;

--- a/dist/index.mjs
+++ b/dist/index.mjs
@@ -1,5 +1,377 @@
-// src/index.mjs
+var __defProp = Object.defineProperty;
+var __getOwnPropNames = Object.getOwnPropertyNames;
+var __esm = (fn, res) => function __init() {
+  return fn && (res = (0, fn[__getOwnPropNames(fn)[0]])(fn = 0)), res;
+};
+var __export = (target, all) => {
+  for (var name in all)
+    __defProp(target, name, { get: all[name], enumerable: true });
+};
+
+// src/cors-config.mjs
+function withCORS(additionalHeaders = {}) {
+  return {
+    ...CORS_HEADERS,
+    ...additionalHeaders
+  };
+}
+function withBasicCORS(additionalHeaders = {}) {
+  return {
+    ...BASIC_CORS_HEADERS,
+    ...additionalHeaders
+  };
+}
+var CORS_HEADERS, BASIC_CORS_HEADERS;
+var init_cors_config = __esm({
+  "src/cors-config.mjs"() {
+    CORS_HEADERS = {
+      "Access-Control-Allow-Origin": "*",
+      "Access-Control-Allow-Headers": "Content-Type, Accept, Authorization, Mcp-Protocol-Version, Mcp-Session-Id",
+      "Access-Control-Allow-Methods": "GET, POST, OPTIONS"
+    };
+    BASIC_CORS_HEADERS = {
+      "Access-Control-Allow-Origin": "*"
+    };
+  }
+});
+
+// src/auth/bearer-token.mjs
+function createAuthErrorResponse(statusCode, error, message, additionalHeaders = {}) {
+  const headers = withCORS({
+    "Content-Type": "application/json",
+    ...additionalHeaders
+  });
+  return {
+    statusCode,
+    headers,
+    body: JSON.stringify({
+      error,
+      message
+    })
+  };
+}
+function validateBearerToken(event, config = {}) {
+  const authHeader = event.headers?.authorization || event.headers?.Authorization;
+  if (!authHeader) {
+    return {
+      isValid: false,
+      error: createAuthErrorResponse(
+        401,
+        "unauthorized",
+        "Authorization header is required",
+        { "WWW-Authenticate": 'Bearer realm="MCP Server"' }
+      )
+    };
+  }
+  if (!authHeader.startsWith("Bearer ")) {
+    return {
+      isValid: false,
+      error: createAuthErrorResponse(
+        401,
+        "unauthorized",
+        "Bearer token is required",
+        { "WWW-Authenticate": 'Bearer realm="MCP Server"' }
+      )
+    };
+  }
+  const token = authHeader.substring(7);
+  if (config.validate && typeof config.validate === "function") {
+    try {
+      const result = config.validate(token, event);
+      if (result && result.isValid) {
+        return {
+          isValid: true,
+          user: result.user || { token },
+          token
+        };
+      } else {
+        return {
+          isValid: false,
+          error: result?.error || createAuthErrorResponse(
+            401,
+            "invalid_token",
+            "Invalid or expired token",
+            { "WWW-Authenticate": 'Bearer realm="MCP Server"' }
+          )
+        };
+      }
+    } catch (error) {
+      console.error("Error in custom token validation:", error);
+      return {
+        isValid: false,
+        error: createAuthErrorResponse(
+          500,
+          "server_error",
+          "Authentication validation error"
+        )
+      };
+    }
+  }
+  const validTokens = config.tokens || [];
+  if (validTokens.length === 0) {
+    console.warn("No valid tokens configured for Bearer token authentication.");
+    return {
+      isValid: false,
+      error: createAuthErrorResponse(
+        500,
+        "server_error",
+        "Authentication not configured"
+      )
+    };
+  }
+  if (!validTokens.includes(token)) {
+    return {
+      isValid: false,
+      error: createAuthErrorResponse(
+        401,
+        "invalid_token",
+        "Invalid or expired token",
+        { "WWW-Authenticate": 'Bearer realm="MCP Server"' }
+      )
+    };
+  }
+  return {
+    isValid: true,
+    user: { token },
+    token
+  };
+}
+var init_bearer_token = __esm({
+  "src/auth/bearer-token.mjs"() {
+    init_cors_config();
+  }
+});
+
+// src/auth/middleware.mjs
+var middleware_exports = {};
+__export(middleware_exports, {
+  createAuthMiddleware: () => createAuthMiddleware,
+  createAuthenticatedHandler: () => createAuthenticatedHandler
+});
+function handleCORSPreflight(event) {
+  const method = event.requestContext?.http?.method || event.httpMethod;
+  if (method === "OPTIONS") {
+    return {
+      statusCode: 200,
+      headers: CORS_HEADERS,
+      body: ""
+    };
+  }
+  return null;
+}
+function createAuthMiddleware(authConfig) {
+  return async (event) => {
+    const corsResponse = handleCORSPreflight(event);
+    if (corsResponse) {
+      return corsResponse;
+    }
+    let authResult;
+    switch (authConfig.type) {
+      case "bearer-token":
+        authResult = validateBearerToken(event, authConfig);
+        break;
+      default:
+        console.error(`Unsupported authentication type: ${authConfig.type}`);
+        return {
+          statusCode: 500,
+          headers: withBasicCORS({ "Content-Type": "application/json" }),
+          body: JSON.stringify({
+            error: "server_error",
+            message: "Unsupported authentication type"
+          })
+        };
+    }
+    if (!authResult.isValid) {
+      console.log("Authentication failed:", authResult.error.body);
+      return authResult.error;
+    }
+    event.user = authResult.user;
+    event.authToken = authResult.token;
+    console.log("Authentication successful");
+    return null;
+  };
+}
+function createAuthenticatedHandler(originalHandler, authConfig) {
+  const authMiddleware = createAuthMiddleware(authConfig);
+  return async (event) => {
+    console.log("=== MCP Server Request Start (with Authentication) ===");
+    console.log("Event:", JSON.stringify(event, null, 2));
+    try {
+      const authResponse = await authMiddleware(event);
+      if (authResponse) {
+        return authResponse;
+      }
+      const response = await originalHandler(event);
+      console.log("=== MCP Server Request End ===");
+      return response;
+    } catch (error) {
+      console.error("Error in authenticated MCP server:", error);
+      return {
+        statusCode: 500,
+        headers: withBasicCORS({ "Content-Type": "application/json" }),
+        body: JSON.stringify({
+          error: "internal_server_error",
+          message: "An internal server error occurred"
+        })
+      };
+    }
+  };
+}
+var init_middleware = __esm({
+  "src/auth/middleware.mjs"() {
+    init_bearer_token();
+    init_cors_config();
+  }
+});
+
+// src/schema-utils.mjs
 import { z } from "zod";
+function zodToJsonSchema(zodSchema) {
+  const properties = {};
+  const required = [];
+  for (const [key, schema] of Object.entries(zodSchema)) {
+    properties[key] = convertZodTypeToJsonSchema(schema);
+    if (!isZodOptional(schema)) {
+      required.push(key);
+    }
+  }
+  return {
+    type: "object",
+    properties,
+    required
+  };
+}
+function convertZodTypeToJsonSchema(zodType) {
+  if (zodType instanceof z.ZodOptional) {
+    return convertZodTypeToJsonSchema(zodType._def.innerType);
+  }
+  if (zodType instanceof z.ZodDefault) {
+    const schema = convertZodTypeToJsonSchema(zodType._def.innerType);
+    schema.default = zodType._def.defaultValue();
+    return schema;
+  }
+  if (zodType instanceof z.ZodString) {
+    const schema = { type: "string" };
+    if (zodType._def.checks) {
+      for (const check of zodType._def.checks) {
+        switch (check.kind) {
+          case "min":
+            schema.minLength = check.value;
+            break;
+          case "max":
+            schema.maxLength = check.value;
+            break;
+          case "email":
+            schema.format = "email";
+            break;
+          case "url":
+            schema.format = "uri";
+            break;
+          case "uuid":
+            schema.format = "uuid";
+            break;
+        }
+      }
+    }
+    if (zodType.description) {
+      schema.description = zodType.description;
+    }
+    return schema;
+  }
+  if (zodType instanceof z.ZodNumber) {
+    const schema = { type: "number" };
+    if (zodType._def.checks) {
+      for (const check of zodType._def.checks) {
+        switch (check.kind) {
+          case "min":
+            schema.minimum = check.value;
+            break;
+          case "max":
+            schema.maximum = check.value;
+            break;
+          case "int":
+            schema.type = "integer";
+            break;
+        }
+      }
+    }
+    if (zodType.description) {
+      schema.description = zodType.description;
+    }
+    return schema;
+  }
+  if (zodType instanceof z.ZodBoolean) {
+    const schema = { type: "boolean" };
+    if (zodType.description) {
+      schema.description = zodType.description;
+    }
+    return schema;
+  }
+  if (zodType instanceof z.ZodEnum) {
+    const schema = {
+      type: "string",
+      enum: zodType._def.values
+    };
+    if (zodType.description) {
+      schema.description = zodType.description;
+    }
+    return schema;
+  }
+  if (zodType instanceof z.ZodArray) {
+    const schema = {
+      type: "array",
+      items: convertZodTypeToJsonSchema(zodType._def.type)
+    };
+    if (zodType._def.minLength) {
+      schema.minItems = zodType._def.minLength.value;
+    }
+    if (zodType._def.maxLength) {
+      schema.maxItems = zodType._def.maxLength.value;
+    }
+    if (zodType.description) {
+      schema.description = zodType.description;
+    }
+    return schema;
+  }
+  if (zodType instanceof z.ZodObject) {
+    return zodToJsonSchema(zodType.shape);
+  }
+  return {
+    type: "string",
+    description: zodType.description || "Unknown type"
+  };
+}
+function isZodOptional(zodType) {
+  return zodType instanceof z.ZodOptional || zodType instanceof z.ZodDefault;
+}
+function hasZodDefault(zodType) {
+  return zodType instanceof z.ZodDefault;
+}
+function validateWithZod(zodSchema, args) {
+  const validated = {};
+  for (const [key, schema] of Object.entries(zodSchema)) {
+    try {
+      if (args[key] === void 0 && isZodOptional(schema)) {
+        if (hasZodDefault(schema)) {
+          validated[key] = schema.parse(void 0);
+        }
+        continue;
+      }
+      validated[key] = schema.parse(args[key]);
+    } catch (error) {
+      throw new z.ZodError([
+        {
+          code: "custom",
+          path: [key],
+          message: `${error.message}`
+        }
+      ]);
+    }
+  }
+  return validated;
+}
+
+// src/mcp-server.mjs
 var MCPServer = class {
   constructor(config) {
     this.config = {
@@ -17,14 +389,16 @@ var MCPServer = class {
    * Register a tool with Zod schema validation
    */
   tool(name, inputSchema, handler) {
-    const jsonSchema = this.zodToJsonSchema(inputSchema);
+    const jsonSchema = zodToJsonSchema(inputSchema);
     const validatedHandler = async (args) => {
       try {
-        const validatedArgs = this.validateWithZod(inputSchema, args);
+        const validatedArgs = validateWithZod(inputSchema, args);
         return await handler(validatedArgs);
       } catch (error) {
         if (error.name === "ZodError") {
-          throw new Error(`Validation error: ${error.errors.map((e) => `${e.path.join(".")}: ${e.message}`).join(", ")}`);
+          throw new Error(
+            `Validation error: ${error.errors.map((e) => `${e.path.join(".")}: ${e.message}`).join(", ")}`
+          );
         }
         throw error;
       }
@@ -33,8 +407,7 @@ var MCPServer = class {
       name,
       description: handler.description || `Tool: ${name}`,
       inputSchema: jsonSchema,
-      handler: validatedHandler,
-      zodSchema: inputSchema
+      handler: validatedHandler
     });
     return this;
   }
@@ -51,136 +424,34 @@ var MCPServer = class {
     return this;
   }
   /**
-   * Register a prompt
+   * Register a prompt with Zod schema validation
    */
   prompt(name, inputSchema, handler) {
-    const jsonSchema = this.zodToJsonSchema(inputSchema);
+    zodToJsonSchema(inputSchema);
+    const validatedHandler = async (args) => {
+      try {
+        const validatedArgs = validateWithZod(inputSchema, args);
+        return await handler(validatedArgs);
+      } catch (error) {
+        if (error.name === "ZodError") {
+          throw new Error(
+            `Validation error: ${error.errors.map((e) => `${e.path.join(".")}: ${e.message}`).join(", ")}`
+          );
+        }
+        throw error;
+      }
+    };
     this.prompts.set(name, {
       name,
       description: handler.description || `Prompt: ${name}`,
-      inputSchema: jsonSchema,
-      handler,
-      zodSchema: inputSchema
+      arguments: Object.entries(inputSchema).map(([key, schema]) => ({
+        name: key,
+        description: schema.description || `${key} parameter`,
+        required: !isZodOptional(schema)
+      })),
+      handler: validatedHandler
     });
     return this;
-  }
-  /**
-   * Convert Zod schema object to JSON Schema
-   */
-  zodToJsonSchema(zodSchema) {
-    const properties = {};
-    const required = [];
-    for (const [key, schema] of Object.entries(zodSchema)) {
-      const jsonSchemaProperty = this.convertZodToJsonSchema(schema);
-      properties[key] = jsonSchemaProperty;
-      if (!this.isZodOptional(schema) && !this.hasZodDefault(schema)) {
-        required.push(key);
-      }
-    }
-    return {
-      type: "object",
-      properties,
-      required
-    };
-  }
-  /**
-   * Convert individual Zod schema to JSON Schema property
-   */
-  convertZodToJsonSchema(zodSchema) {
-    if (zodSchema._def.typeName === "ZodOptional") {
-      return this.convertZodToJsonSchema(zodSchema._def.innerType);
-    }
-    if (zodSchema._def.typeName === "ZodDefault") {
-      const baseSchema = this.convertZodToJsonSchema(zodSchema._def.innerType);
-      baseSchema.default = zodSchema._def.defaultValue();
-      return baseSchema;
-    }
-    switch (zodSchema._def.typeName) {
-      case "ZodString":
-        return {
-          type: "string",
-          description: zodSchema.description || "String value"
-        };
-      case "ZodNumber":
-        return {
-          type: "number",
-          description: zodSchema.description || "Numeric value"
-        };
-      case "ZodBoolean":
-        return {
-          type: "boolean",
-          description: zodSchema.description || "Boolean value"
-        };
-      case "ZodEnum":
-        return {
-          type: "string",
-          enum: zodSchema._def.values,
-          description: zodSchema.description || `One of: ${zodSchema._def.values.join(", ")}`
-        };
-      case "ZodArray":
-        return {
-          type: "array",
-          items: this.convertZodToJsonSchema(zodSchema._def.type),
-          description: zodSchema.description || "Array of values"
-        };
-      case "ZodObject":
-        const nestedProperties = {};
-        const nestedRequired = [];
-        for (const [key, nestedSchema] of Object.entries(zodSchema._def.shape())) {
-          nestedProperties[key] = this.convertZodToJsonSchema(nestedSchema);
-          if (!this.isZodOptional(nestedSchema)) {
-            nestedRequired.push(key);
-          }
-        }
-        return {
-          type: "object",
-          properties: nestedProperties,
-          required: nestedRequired,
-          description: zodSchema.description || "Object value"
-        };
-      default:
-        console.warn(`Unknown Zod type: ${zodSchema._def.typeName}, defaulting to string`);
-        return {
-          type: "string",
-          description: zodSchema.description || "String value"
-        };
-    }
-  }
-  /**
-   * Check if Zod schema is optional
-   */
-  isZodOptional(zodSchema) {
-    return zodSchema._def.typeName === "ZodOptional" || zodSchema._def.typeName === "ZodDefault";
-  }
-  /**
-   * Check if Zod schema has default value
-   */
-  hasZodDefault(zodSchema) {
-    return zodSchema._def.typeName === "ZodDefault";
-  }
-  /**
-   * Validate arguments with Zod schema
-   */
-  validateWithZod(zodSchema, args) {
-    const validated = {};
-    for (const [key, schema] of Object.entries(zodSchema)) {
-      try {
-        if (args[key] === void 0 && this.isZodOptional(schema)) {
-          if (this.hasZodDefault(schema)) {
-            validated[key] = schema.parse(void 0);
-          }
-          continue;
-        }
-        validated[key] = schema.parse(args[key]);
-      } catch (error) {
-        throw new z.ZodError([{
-          code: "custom",
-          path: [key],
-          message: `${error.message}`
-        }]);
-      }
-    }
-    return validated;
   }
   /**
    * Handle MCP protocol requests
@@ -210,16 +481,13 @@ var MCPServer = class {
   /**
    * Handle initialize request
    */
-  async handleInitialize(params) {
-    const clientVersion = params.protocolVersion;
-    const supportedVersions = ["2024-11-05", "2025-03-26"];
-    const negotiatedVersion = supportedVersions.includes(clientVersion) ? clientVersion : this.config.protocolVersion;
+  async handleInitialize() {
     return {
-      protocolVersion: negotiatedVersion,
+      protocolVersion: this.config.protocolVersion,
       capabilities: {
-        tools: this.tools.size > 0 ? { listChanged: true } : void 0,
-        resources: this.resources.size > 0 ? { listChanged: true } : void 0,
-        prompts: this.prompts.size > 0 ? { listChanged: true } : void 0
+        tools: { listChanged: true },
+        resources: { listChanged: true },
+        prompts: { listChanged: true }
       },
       serverInfo: {
         name: this.config.name,
@@ -231,7 +499,7 @@ var MCPServer = class {
   /**
    * Handle tools/list request
    */
-  async handleToolsList(params) {
+  async handleToolsList() {
     const tools = Array.from(this.tools.values()).map((tool) => ({
       name: tool.name,
       description: tool.description,
@@ -243,22 +511,30 @@ var MCPServer = class {
    * Handle tools/call request
    */
   async handleToolsCall(params) {
-    if (!params || !params.name) {
+    if (!params?.name) {
       throw new Error("Tool name is required");
     }
     const tool = this.tools.get(params.name);
     if (!tool) {
       throw new Error(`Tool not found: ${params.name}`);
     }
-    return await tool.handler(params.arguments || {});
+    try {
+      const result = await tool.handler(params.arguments || {});
+      return result;
+    } catch (error) {
+      return {
+        content: [{ type: "text", text: `Error: ${error.message}` }],
+        isError: true
+      };
+    }
   }
   /**
    * Handle resources/list request
    */
-  async handleResourcesList(params) {
+  async handleResourcesList() {
     const resources = Array.from(this.resources.values()).map((resource) => ({
-      name: resource.name,
       uri: resource.uri,
+      name: resource.name,
       description: resource.description
     }));
     return { resources };
@@ -267,23 +543,30 @@ var MCPServer = class {
    * Handle resources/read request
    */
   async handleResourcesRead(params) {
-    if (!params || !params.uri) {
+    if (!params?.uri) {
       throw new Error("Resource URI is required");
     }
-    const resource = Array.from(this.resources.values()).find((r) => r.uri === params.uri);
+    const resource = Array.from(this.resources.values()).find(
+      (r) => r.uri === params.uri
+    );
     if (!resource) {
       throw new Error(`Resource not found: ${params.uri}`);
     }
-    return await resource.handler(params.uri);
+    try {
+      const result = await resource.handler(params.uri);
+      return result;
+    } catch (error) {
+      throw new Error(`Resource read error: ${error.message}`);
+    }
   }
   /**
    * Handle prompts/list request
    */
-  async handlePromptsList(params) {
+  async handlePromptsList() {
     const prompts = Array.from(this.prompts.values()).map((prompt) => ({
       name: prompt.name,
       description: prompt.description,
-      arguments: this.jsonSchemaToPromptArgs(prompt.inputSchema)
+      arguments: prompt.arguments
     }));
     return { prompts };
   }
@@ -291,29 +574,19 @@ var MCPServer = class {
    * Handle prompts/get request
    */
   async handlePromptsGet(params) {
-    if (!params || !params.name) {
+    if (!params?.name) {
       throw new Error("Prompt name is required");
     }
     const prompt = this.prompts.get(params.name);
     if (!prompt) {
       throw new Error(`Prompt not found: ${params.name}`);
     }
-    const validatedArgs = this.validateWithZod(prompt.zodSchema, params.arguments || {});
-    return await prompt.handler(validatedArgs);
-  }
-  /**
-   * Convert JSON Schema to prompt arguments format
-   */
-  jsonSchemaToPromptArgs(jsonSchema) {
-    const args = [];
-    for (const [name, property] of Object.entries(jsonSchema.properties || {})) {
-      args.push({
-        name,
-        description: property.description || `${name} parameter`,
-        required: jsonSchema.required?.includes(name) || false
-      });
+    try {
+      const result = await prompt.handler(params.arguments || {});
+      return result;
+    } catch (error) {
+      throw new Error(`Prompt execution error: ${error.message}`);
     }
-    return args;
   }
   /**
    * Get server statistics
@@ -327,114 +600,191 @@ var MCPServer = class {
     };
   }
 };
-function createLambdaHandler(mcpServer) {
-  return async (event, context) => {
-    try {
-      const method = event.httpMethod;
-      const headers = event.headers || {};
-      const corsHeaders = {
-        "Access-Control-Allow-Origin": "*",
-        "Access-Control-Allow-Headers": "Content-Type, Accept, Mcp-Protocol-Version, Mcp-Session-Id",
-        "Access-Control-Allow-Methods": "POST, GET, OPTIONS"
-      };
-      if (method === "OPTIONS") {
-        return createResponse("", 200, corsHeaders);
-      }
-      if (method === "POST") {
-        return await handleMCPRequest(mcpServer, event.body, headers, corsHeaders);
-      }
-      if (method === "GET") {
-        return createErrorResponse(405, -32e3, "Method not allowed: Stateless mode", corsHeaders);
-      }
-      return createErrorResponse(405, -32e3, `Method not allowed: ${method}`, corsHeaders);
-    } catch (error) {
-      console.error("Lambda error:", error);
-      return createErrorResponse(500, -32603, "Internal server error", {
-        "Content-Type": "application/json",
-        "Access-Control-Allow-Origin": "*"
-      });
-    }
+
+// src/lambda-adapter.mjs
+init_cors_config();
+function createResponse(body, statusCode = 200, headers = {}) {
+  return {
+    statusCode,
+    headers: {
+      "Content-Type": "application/json",
+      ...headers
+    },
+    body: typeof body === "string" ? body : JSON.stringify(body)
   };
+}
+function createErrorResponse(statusCode, code, message, headers = {}, id = null) {
+  return createResponse(
+    {
+      jsonrpc: "2.0",
+      error: { code, message },
+      id
+    },
+    statusCode,
+    headers
+  );
 }
 async function handleMCPRequest(mcpServer, body, headers, corsHeaders) {
   const contentType = headers["content-type"] || headers["Content-Type"] || "";
   if (!contentType.includes("application/json")) {
-    return createErrorResponse(400, -32700, "Parse error: Content-Type must be application/json", corsHeaders);
+    return createErrorResponse(
+      400,
+      -32700,
+      "Parse error: Content-Type must be application/json",
+      corsHeaders
+    );
   }
   let jsonRpcMessage;
   try {
     jsonRpcMessage = JSON.parse(body || "{}");
-  } catch (error) {
-    return createErrorResponse(400, -32700, "Parse error: Invalid JSON", corsHeaders);
+  } catch {
+    return createErrorResponse(
+      400,
+      -32700,
+      "Parse error: Invalid JSON",
+      corsHeaders
+    );
   }
   if (!jsonRpcMessage.jsonrpc || jsonRpcMessage.jsonrpc !== "2.0") {
-    return createErrorResponse(400, -32600, "Invalid Request: missing jsonrpc field", corsHeaders, jsonRpcMessage.id);
+    return createErrorResponse(
+      400,
+      -32600,
+      "Invalid Request: missing jsonrpc field",
+      corsHeaders,
+      jsonRpcMessage.id
+    );
+  }
+  if (!jsonRpcMessage.method) {
+    return createErrorResponse(
+      400,
+      -32600,
+      "Invalid Request: missing method field",
+      corsHeaders,
+      jsonRpcMessage.id
+    );
   }
   try {
-    const response = await mcpServer.handleRequest(jsonRpcMessage);
-    if (response === null) {
-      return { statusCode: 202, headers: corsHeaders, body: "" };
+    const result = await mcpServer.handleRequest(jsonRpcMessage);
+    if (result === null) {
+      return createResponse("", 204, corsHeaders);
     }
     return createResponse(
-      JSON.stringify({
-        jsonrpc: "2.0",
-        id: jsonRpcMessage.id,
-        result: response
-      }),
-      200,
       {
-        ...corsHeaders,
-        "Content-Type": "application/json",
-        "Mcp-Protocol-Version": mcpServer.config.protocolVersion
-      }
+        jsonrpc: "2.0",
+        result,
+        id: jsonRpcMessage.id
+      },
+      200,
+      corsHeaders
     );
   } catch (error) {
-    console.error("MCP processing error:", error);
+    console.error("MCP request error:", error);
     let errorCode = -32603;
-    if (error.message.includes("not found"))
+    let errorMessage = error.message;
+    if (error.message.includes("Method not found")) {
       errorCode = -32601;
-    else if (error.message.includes("Validation error"))
+    } else if (error.message.includes("not found") || error.message.includes("required")) {
       errorCode = -32602;
-    return createErrorResponse(200, errorCode, error.message, corsHeaders, jsonRpcMessage.id);
+    }
+    return createErrorResponse(
+      500,
+      errorCode,
+      errorMessage,
+      corsHeaders,
+      jsonRpcMessage.id
+    );
   }
 }
-function createResponse(body, statusCode = 200, headers = {}) {
-  return {
-    statusCode,
-    headers: { "Content-Type": "application/json", ...headers },
-    body
+function createLambdaHandler(mcpServer, options = {}) {
+  const baseHandler = async (event) => {
+    try {
+      const method = event.httpMethod || event.requestContext?.http?.method;
+      const headers = event.headers || {};
+      if (method === "OPTIONS") {
+        return createResponse("", 200, CORS_HEADERS);
+      }
+      if (method === "POST") {
+        return await handleMCPRequest(
+          mcpServer,
+          event.body,
+          headers,
+          CORS_HEADERS
+        );
+      }
+      if (method === "GET") {
+        return createErrorResponse(
+          405,
+          -32e3,
+          "Method not allowed: Stateless mode",
+          CORS_HEADERS
+        );
+      }
+      return createErrorResponse(
+        405,
+        -32e3,
+        `Method not allowed: ${method}`,
+        CORS_HEADERS
+      );
+    } catch (error) {
+      console.error("Lambda error:", error);
+      return createErrorResponse(
+        500,
+        -32603,
+        "Internal server error",
+        withBasicCORS({ "Content-Type": "application/json" })
+      );
+    }
   };
+  if (options.auth) {
+    return async (event, context) => {
+      try {
+        const { createAuthenticatedHandler: createAuthenticatedHandler2 } = await Promise.resolve().then(() => (init_middleware(), middleware_exports));
+        const authenticatedHandler = createAuthenticatedHandler2(
+          baseHandler,
+          options.auth
+        );
+        return await authenticatedHandler(event, context);
+      } catch (error) {
+        console.error("Authentication module error:", error);
+        return {
+          statusCode: 500,
+          headers: withBasicCORS({ "Content-Type": "application/json" }),
+          body: JSON.stringify({
+            error: "server_error",
+            message: "Authentication module not available"
+          })
+        };
+      }
+    };
+  }
+  return baseHandler;
 }
-function createErrorResponse(statusCode, errorCode, message, headers = {}, id = null) {
-  return {
-    statusCode,
-    headers: { "Content-Type": "application/json", ...headers },
-    body: JSON.stringify({
-      jsonrpc: "2.0",
-      error: { code: errorCode, message },
-      id
-    })
-  };
-}
+
+// src/common-schemas.mjs
+import { z as z2 } from "zod";
+var CommonSchemas = {
+  // Basic types
+  string: z2.string(),
+  number: z2.number(),
+  boolean: z2.boolean(),
+  // Optional types
+  optionalString: z2.string().optional(),
+  optionalNumber: z2.number().optional(),
+  optionalBoolean: z2.boolean().optional(),
+  // Common patterns
+  email: z2.string().email(),
+  url: z2.string().url(),
+  uuid: z2.string().uuid(),
+  // Utility functions
+  enum: (values) => z2.enum(values),
+  array: (itemSchema) => z2.array(itemSchema),
+  object: (shape) => z2.object(shape)
+};
+
+// src/index.mjs
 function createMCPServer(config) {
   return new MCPServer(config);
 }
-var CommonSchemas = {
-  string: z.string(),
-  number: z.number(),
-  boolean: z.boolean(),
-  optionalString: z.string().optional(),
-  optionalNumber: z.number().optional(),
-  optionalBoolean: z.boolean().optional(),
-  // Common patterns
-  email: z.string().email(),
-  url: z.string().url(),
-  uuid: z.string().uuid(),
-  // Utility functions
-  enum: (values) => z.enum(values),
-  array: (itemSchema) => z.array(itemSchema),
-  object: (shape) => z.object(shape)
-};
 export {
   CommonSchemas,
   MCPServer,

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,0 +1,25 @@
+import js from '@eslint/js';
+import globals from 'globals';
+import tseslint from 'typescript-eslint';
+
+export default tseslint.config(
+  js.configs.recommended,
+  ...tseslint.configs.recommended,
+  {
+    languageOptions: {
+      globals: {
+        ...globals.node,
+      },
+    },
+  },
+  {
+    files: ['**/*.{js,mjs,cjs,ts}'],
+    rules: {
+      // 基本的なデフォルト設定を使用
+      '@typescript-eslint/no-unused-vars': 'error',
+    },
+  },
+  {
+    ignores: ['dist/', 'node_modules/', '*.config.js'],
+  }
+);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,26 @@
 {
-  "name": "@aws-lambda-mcp/adapter",
+  "name": "lambda-mcp-adaptor",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@aws-lambda-mcp/adapter",
+      "name": "lambda-mcp-adaptor",
       "version": "1.0.0",
-      "license": "MIT",
+      "license": "Apache-2.0",
       "devDependencies": {
+        "@eslint/js": "^9.29.0",
+        "@typescript-eslint/eslint-plugin": "^8.34.0",
+        "@typescript-eslint/parser": "^8.34.0",
         "chai": "^4.3.6",
         "esbuild": "^0.19.0",
+        "eslint": "^9.29.0",
+        "eslint-config-prettier": "^10.1.5",
+        "eslint-plugin-prettier": "^5.4.1",
+        "globals": "^16.2.0",
         "mocha": "^10.2.0",
+        "prettier": "^3.5.3",
+        "typescript-eslint": "^8.34.0",
         "zod": "^3.22.4"
       },
       "engines": {
@@ -412,6 +421,639 @@
         "node": ">=12"
       }
     },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.7.0.tgz",
+      "integrity": "sha512-dyybb3AcajC7uha6CvhdVRJqaKyn7w2YKqKyAN37NKYgZT36w+iRb0Dymmc5qEJ549c/S31cMMSFd75bteCpCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.1.tgz",
+      "integrity": "sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/config-array": {
+      "version": "0.20.1",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.20.1.tgz",
+      "integrity": "sha512-OL0RJzC/CBzli0DrrR31qzj6d6i6Mm3HByuhflhl4LOBiWxN+3i6/t/ZQQNii4tjksXi8r2CRW1wMpWA2ULUEw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/object-schema": "^2.1.6",
+        "debug": "^4.3.1",
+        "minimatch": "^3.1.2"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/config-array/node_modules/brace-expansion": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/@eslint/config-array/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@eslint/config-helpers": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.2.3.tgz",
+      "integrity": "sha512-u180qk2Um1le4yf0ruXH3PYFeEZeYC3p/4wCTKrr2U1CmGdzGi3KtY0nuPDH48UJxlKCC5RDzbcbh4X0XlqgHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/core": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.14.0.tgz",
+      "integrity": "sha512-qIbV0/JZr7iSDjqAc60IqbLdsj9GDt16xQtWD+B78d/HAlvysGdZZ6rpJHGAc2T0FQx1X6thsSPdnoiGKdNtdg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/eslintrc": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.1.tgz",
+      "integrity": "sha512-gtF186CXhIl1p4pJNGZw8Yc6RlshoePRvE0X91oPGb3vZ8pM3qOS9W9NGPat9LziaBV7XrJWGylNQXkGcnM3IQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^6.12.4",
+        "debug": "^4.3.2",
+        "espree": "^10.0.1",
+        "globals": "^14.0.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.0",
+        "minimatch": "^3.1.2",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/globals": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
+      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "9.29.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.29.0.tgz",
+      "integrity": "sha512-3PIF4cBw/y+1u2EazflInpV+lYsSG0aByVIQzAgb1m1MhHFSbqTyNqtBKHgWf/9Ykud+DhILS9EGkmekVhbKoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      }
+    },
+    "node_modules/@eslint/object-schema": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.6.tgz",
+      "integrity": "sha512-RBMg5FRL0I0gs51M/guSAj5/e14VQ4tpZnQNWwuDT66P14I43ItmPfIZRhO9fUVIPOAQXU47atlywZ/czoqFPA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/plugin-kit": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.3.2.tgz",
+      "integrity": "sha512-4SaFZCNfJqvk/kenHpI8xvN42DMaoycy4PzKc5otHxRswww1kAt82OlBuwRVLofCACCTZEcla2Ydxv8scMXaTg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.15.0",
+        "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/plugin-kit/node_modules/@eslint/core": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.15.0.tgz",
+      "integrity": "sha512-b7ePw78tEWWkpgZCDYkbqDOP8dmM6qe+AOC6iuJqlq1R/0ahMAeH3qynpnqKFGkMltrp44ohV4ubGyvLX28tzw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@humanfs/core": {
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
+      "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node": {
+      "version": "0.16.6",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.6.tgz",
+      "integrity": "sha512-YuI2ZHQL78Q5HbhDiBA1X4LmYdXCKCMQIfw0pw7piHJwyREFebJUvrQN4cMssyES6x+vfUbx1CIpaQUKYdQZOw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/core": "^0.19.1",
+        "@humanwhocodes/retry": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node/node_modules/@humanwhocodes/retry": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.3.1.tgz",
+      "integrity": "sha512-JBxkERygn7Bv/GbN5Rv8Ul6LVknS+5Bp6RgDC/O8gEBU/yeH5Ui5C/OlWrTb6qct7LjjfT6Re2NxB0ln0yYybA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/retry": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@pkgr/core": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.2.7.tgz",
+      "integrity": "sha512-YLT9Zo3oNPJoBjBc4q8G2mjU4tqIbf5CEOORbUUr48dCD9q3umJ3IPlVqOqDakPfd2HuwccBaqlGhN4Gmr5OWg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/pkgr"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "8.34.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.34.0.tgz",
+      "integrity": "sha512-QXwAlHlbcAwNlEEMKQS2RCgJsgXrTJdjXT08xEgbPFa2yYQgVjBymxP5DrfrE7X7iodSzd9qBUHUycdyVJTW1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.10.0",
+        "@typescript-eslint/scope-manager": "8.34.0",
+        "@typescript-eslint/type-utils": "8.34.0",
+        "@typescript-eslint/utils": "8.34.0",
+        "@typescript-eslint/visitor-keys": "8.34.0",
+        "graphemer": "^1.4.0",
+        "ignore": "^7.0.0",
+        "natural-compare": "^1.4.0",
+        "ts-api-utils": "^2.1.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^8.34.0",
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": ">=4.8.4 <5.9.0"
+      }
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "8.34.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.34.0.tgz",
+      "integrity": "sha512-vxXJV1hVFx3IXz/oy2sICsJukaBrtDEQSBiV48/YIV5KWjX1dO+bcIr/kCPrW6weKXvsaGKFNlwH0v2eYdRRbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "8.34.0",
+        "@typescript-eslint/types": "8.34.0",
+        "@typescript-eslint/typescript-estree": "8.34.0",
+        "@typescript-eslint/visitor-keys": "8.34.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": ">=4.8.4 <5.9.0"
+      }
+    },
+    "node_modules/@typescript-eslint/project-service": {
+      "version": "8.34.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.34.0.tgz",
+      "integrity": "sha512-iEgDALRf970/B2YExmtPMPF54NenZUf4xpL3wsCRx/lgjz6ul/l13R81ozP/ZNuXfnLCS+oPmG7JIxfdNYKELw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.34.0",
+        "@typescript-eslint/types": "^8.34.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <5.9.0"
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.34.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.34.0.tgz",
+      "integrity": "sha512-9Ac0X8WiLykl0aj1oYQNcLZjHgBojT6cW68yAgZ19letYu+Hxd0rE0veI1XznSSst1X5lwnxhPbVdwjDRIomRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.34.0",
+        "@typescript-eslint/visitor-keys": "8.34.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.34.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.34.0.tgz",
+      "integrity": "sha512-+W9VYHKFIzA5cBeooqQxqNriAP0QeQ7xTiDuIOr71hzgffm3EL2hxwWBIIj4GuofIbKxGNarpKqIq6Q6YrShOA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <5.9.0"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "8.34.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.34.0.tgz",
+      "integrity": "sha512-n7zSmOcUVhcRYC75W2pnPpbO1iwhJY3NLoHEtbJwJSNlVAZuwqu05zY3f3s2SDWWDSo9FdN5szqc73DCtDObAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/typescript-estree": "8.34.0",
+        "@typescript-eslint/utils": "8.34.0",
+        "debug": "^4.3.4",
+        "ts-api-utils": "^2.1.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": ">=4.8.4 <5.9.0"
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "8.34.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.34.0.tgz",
+      "integrity": "sha512-9V24k/paICYPniajHfJ4cuAWETnt7Ssy+R0Rbcqo5sSFr3QEZ/8TSoUi9XeXVBGXCaLtwTOKSLGcInCAvyZeMA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.34.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.34.0.tgz",
+      "integrity": "sha512-rOi4KZxI7E0+BMqG7emPSK1bB4RICCpF7QD3KCLXn9ZvWoESsOMlHyZPAHyG04ujVplPaHbmEvs34m+wjgtVtg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.34.0",
+        "@typescript-eslint/tsconfig-utils": "8.34.0",
+        "@typescript-eslint/types": "8.34.0",
+        "@typescript-eslint/visitor-keys": "8.34.0",
+        "debug": "^4.3.4",
+        "fast-glob": "^3.3.2",
+        "is-glob": "^4.0.3",
+        "minimatch": "^9.0.4",
+        "semver": "^7.6.0",
+        "ts-api-utils": "^2.1.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <5.9.0"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@typescript-eslint/utils": {
+      "version": "8.34.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.34.0.tgz",
+      "integrity": "sha512-8L4tWatGchV9A1cKbjaavS6mwYwp39jql8xUmIIKJdm+qiaeHy5KMKlBrf30akXAWBzn2SqKsNOtSENWUwg7XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.7.0",
+        "@typescript-eslint/scope-manager": "8.34.0",
+        "@typescript-eslint/types": "8.34.0",
+        "@typescript-eslint/typescript-estree": "8.34.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": ">=4.8.4 <5.9.0"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.34.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.34.0.tgz",
+      "integrity": "sha512-qHV7pW7E85A0x6qyrFn+O+q1k1p3tQCsqIZ1KZ5ESLXY57aTvUd3/a4rdPTeXisvhXn2VQG0VSKUqs8KHF2zcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.34.0",
+        "eslint-visitor-keys": "^4.2.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.15.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
+      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
     "node_modules/ansi-colors": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
@@ -528,6 +1170,16 @@
       "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/camelcase": {
       "version": "6.3.0",
@@ -661,6 +1313,28 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
@@ -704,6 +1378,13 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/diff": {
       "version": "5.2.0",
@@ -784,6 +1465,349 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/eslint": {
+      "version": "9.29.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.29.0.tgz",
+      "integrity": "sha512-GsGizj2Y1rCWDu6XoEekL3RLilp0voSePurjZIkxL3wlm5o5EC9VpgaP7lrCvjnkuLvzFBQWB3vWB3K5KQTveQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.2.0",
+        "@eslint-community/regexpp": "^4.12.1",
+        "@eslint/config-array": "^0.20.1",
+        "@eslint/config-helpers": "^0.2.1",
+        "@eslint/core": "^0.14.0",
+        "@eslint/eslintrc": "^3.3.1",
+        "@eslint/js": "9.29.0",
+        "@eslint/plugin-kit": "^0.3.1",
+        "@humanfs/node": "^0.16.6",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
+        "@types/json-schema": "^7.0.15",
+        "ajv": "^6.12.4",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.3.2",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^8.4.0",
+        "eslint-visitor-keys": "^4.2.1",
+        "espree": "^10.4.0",
+        "esquery": "^1.5.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^8.0.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.2",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-config-prettier": {
+      "version": "10.1.5",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.5.tgz",
+      "integrity": "sha512-zc1UmCpNltmVY34vuLRV61r1K27sWuX39E+uyUnY8xS2Bex88VV9cugG+UZbRSRGtGyFboj+D8JODyme1plMpw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "eslint-config-prettier": "bin/cli.js"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint-config-prettier"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-prettier": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.4.1.tgz",
+      "integrity": "sha512-9dF+KuU/Ilkq27A8idRP7N2DH8iUR6qXcjF3FR2wETY21PZdBrIjwCau8oboyGj9b7etWmTGEeM8e7oOed6ZWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prettier-linter-helpers": "^1.0.0",
+        "synckit": "^0.11.7"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint-plugin-prettier"
+      },
+      "peerDependencies": {
+        "@types/eslint": ">=8.0.0",
+        "eslint": ">=8.0.0",
+        "eslint-config-prettier": ">= 7.0.0 <10.0.0 || >=10.1.0",
+        "prettier": ">=3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/eslint": {
+          "optional": true
+        },
+        "eslint-config-prettier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
+      "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/brace-expansion": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/eslint/node_modules/eslint-visitor-keys": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/eslint/node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/eslint/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/espree": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^4.2.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/espree/node_modules/eslint-visitor-keys": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.6.0.tgz",
+      "integrity": "sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-diff": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.3.0.tgz",
+      "integrity": "sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/fast-glob": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fastq": {
+      "version": "1.19.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz",
+      "integrity": "sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/file-entry-cache": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
     "node_modules/fill-range": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
@@ -823,6 +1847,27 @@
       "bin": {
         "flat": "cli.js"
       }
+    },
+    "node_modules/flat-cache": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
+      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
@@ -900,6 +1945,26 @@
         "node": ">= 6"
       }
     },
+    "node_modules/globals": {
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-16.2.0.tgz",
+      "integrity": "sha512-O+7l9tPdHCU320IigZZPj5zmRCFG9xHmx9cU8FqU2Rp+JN714seHV+2S9+JslCpY4gJwU2vOGox0wzgae/MCEg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/graphemer": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
+      "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -918,6 +1983,43 @@
       "license": "MIT",
       "bin": {
         "he": "bin/he"
+      }
+    },
+    "node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/import-fresh": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
       }
     },
     "node_modules/inflight": {
@@ -1018,6 +2120,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/js-yaml": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
@@ -1029,6 +2138,51 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
       }
     },
     "node_modules/locate-path": {
@@ -1046,6 +2200,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/log-symbols": {
       "version": "4.1.0",
@@ -1072,6 +2233,30 @@
       "license": "MIT",
       "dependencies": {
         "get-func-name": "^2.0.1"
+      }
+    },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
       }
     },
     "node_modules/minimatch": {
@@ -1130,6 +2315,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/normalize-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
@@ -1148,6 +2340,24 @@
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
+      }
+    },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
       }
     },
     "node_modules/p-limit": {
@@ -1182,10 +2392,33 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
       "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1214,6 +2447,76 @@
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
       }
+    },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.5.3.tgz",
+      "integrity": "sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/prettier-linter-helpers": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",
+      "integrity": "sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-diff": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/randombytes": {
       "version": "2.1.0",
@@ -1248,6 +2551,51 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/reusify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
+      }
+    },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -1269,6 +2617,19 @@
       ],
       "license": "MIT"
     },
+    "node_modules/semver": {
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/serialize-javascript": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
@@ -1277,6 +2638,29 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "randombytes": "^2.1.0"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/string-width": {
@@ -1336,6 +2720,22 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
+    "node_modules/synckit": {
+      "version": "0.11.8",
+      "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.8.tgz",
+      "integrity": "sha512-+XZ+r1XGIJGeQk3VvXhT6xx/VpbHsRzsTkGgF6E5RX9TTXD0118l87puaEBZ566FhqblC6U0d4XnubznJDm30A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@pkgr/core": "^0.2.4"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/synckit"
+      }
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -1349,6 +2749,32 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/ts-api-utils": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.1.0.tgz",
+      "integrity": "sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.12"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4"
+      }
+    },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/type-detect": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.1.0.tgz",
@@ -1357,6 +2783,80 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/typescript-eslint": {
+      "version": "8.34.0",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.34.0.tgz",
+      "integrity": "sha512-MRpfN7uYjTrTGigFCt8sRyNqJFhjN0WwZecldaqhWm+wy0gaRt8Edb/3cuUy0zdq2opJWT6iXINKAtewnDOltQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/eslint-plugin": "8.34.0",
+        "@typescript-eslint/parser": "8.34.0",
+        "@typescript-eslint/utils": "8.34.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": ">=4.8.4 <5.9.0"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/workerpool": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,11 @@
     "build:types": "cp src/index.d.ts dist/index.d.ts",
     "test": "mocha tests/**/*.test.mjs",
     "prepublishOnly": "npm run build",
-    "dev": "node examples/basic-server.mjs"
+    "dev": "node examples/basic-server.mjs",
+    "lint": "eslint src/**/*.{js,ts,mjs} --fix",
+    "lint:check": "eslint src/**/*.{js,ts,mjs}",
+    "format": "prettier --write src/**/*.{js,ts,mjs,json,md}",
+    "format:check": "prettier --check src/**/*.{js,ts,mjs,json,md}"
   },
   "keywords": [
     "mcp",
@@ -52,9 +56,18 @@
     "zod": "^3.22.0"
   },
   "devDependencies": {
-    "esbuild": "^0.19.0",
-    "mocha": "^10.2.0",
+    "@eslint/js": "^9.29.0",
+    "@typescript-eslint/eslint-plugin": "^8.34.0",
+    "@typescript-eslint/parser": "^8.34.0",
     "chai": "^4.3.6",
+    "esbuild": "^0.19.0",
+    "eslint": "^9.29.0",
+    "eslint-config-prettier": "^10.1.5",
+    "eslint-plugin-prettier": "^5.4.1",
+    "globals": "^16.2.0",
+    "mocha": "^10.2.0",
+    "prettier": "^3.5.3",
+    "typescript-eslint": "^8.34.0",
     "zod": "^3.22.4"
   },
   "engines": {

--- a/src/auth/index.mjs
+++ b/src/auth/index.mjs
@@ -1,18 +1,18 @@
 /**
  * Authentication Module
- * 
+ *
  * Provides authentication functionality for MCP servers
  */
 
 export {
   validateBearerToken,
   createBearerTokenConfigFromEnv,
-  createBearerTokenConfigWithValidation
+  createBearerTokenConfigWithValidation,
 } from './bearer-token.mjs';
 
 export {
   createAuthMiddleware,
-  createAuthenticatedHandler
+  createAuthenticatedHandler,
 } from './middleware.mjs';
 
 /**
@@ -26,9 +26,9 @@ export const AuthPresets = {
    */
   bearerTokenFromEnv: (envVar = 'VALID_TOKENS') => ({
     type: 'bearer-token',
-    tokens: (process.env[envVar] || '').split(',').filter(t => t.trim())
+    tokens: (process.env[envVar] || '').split(',').filter((t) => t.trim()),
   }),
-  
+
   /**
    * Bearer token authentication with token list
    * @param {string[]} tokens - Array of valid tokens
@@ -36,9 +36,9 @@ export const AuthPresets = {
    */
   bearerTokenWithList: (tokens) => ({
     type: 'bearer-token',
-    tokens: Array.isArray(tokens) ? tokens : [tokens]
+    tokens: Array.isArray(tokens) ? tokens : [tokens],
   }),
-  
+
   /**
    * Bearer token authentication with custom validation
    * @param {Function} validateFn - Custom validation function
@@ -46,8 +46,8 @@ export const AuthPresets = {
    */
   bearerTokenWithValidation: (validateFn) => ({
     type: 'bearer-token',
-    validate: validateFn
-  })
+    validate: validateFn,
+  }),
 };
 
 /**
@@ -58,22 +58,23 @@ export const Auth = {
    * No authentication (default)
    */
   none: () => null,
-  
+
   /**
    * Bearer token authentication from environment variable
    * @param {string} envVar - Environment variable name
    */
-  bearerToken: (envVar = 'VALID_TOKENS') => AuthPresets.bearerTokenFromEnv(envVar),
-  
+  bearerToken: (envVar = 'VALID_TOKENS') =>
+    AuthPresets.bearerTokenFromEnv(envVar),
+
   /**
    * Bearer token authentication with token list
    * @param {string|string[]} tokens - Token or array of tokens
    */
   bearerTokens: (tokens) => AuthPresets.bearerTokenWithList(tokens),
-  
+
   /**
    * Custom bearer token validation
    * @param {Function} validateFn - Validation function
    */
-  custom: (validateFn) => AuthPresets.bearerTokenWithValidation(validateFn)
+  custom: (validateFn) => AuthPresets.bearerTokenWithValidation(validateFn),
 };

--- a/src/common-schemas.mjs
+++ b/src/common-schemas.mjs
@@ -1,6 +1,6 @@
 /**
  * Common Zod Schemas
- * 
+ *
  * Pre-defined schemas for common use cases
  */
 
@@ -14,19 +14,19 @@ export const CommonSchemas = {
   string: z.string(),
   number: z.number(),
   boolean: z.boolean(),
-  
+
   // Optional types
   optionalString: z.string().optional(),
   optionalNumber: z.number().optional(),
   optionalBoolean: z.boolean().optional(),
-  
+
   // Common patterns
   email: z.string().email(),
   url: z.string().url(),
   uuid: z.string().uuid(),
-  
+
   // Utility functions
   enum: (values) => z.enum(values),
   array: (itemSchema) => z.array(itemSchema),
-  object: (shape) => z.object(shape)
+  object: (shape) => z.object(shape),
 };

--- a/src/cors-config.mjs
+++ b/src/cors-config.mjs
@@ -1,6 +1,6 @@
 /**
  * CORS Configuration
- * 
+ *
  * Centralized CORS headers configuration for consistent handling across all modules
  */
 
@@ -10,15 +10,16 @@
  */
 export const CORS_HEADERS = {
   'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'Content-Type, Accept, Authorization, Mcp-Protocol-Version, Mcp-Session-Id',
-  'Access-Control-Allow-Methods': 'GET, POST, OPTIONS'
+  'Access-Control-Allow-Headers':
+    'Content-Type, Accept, Authorization, Mcp-Protocol-Version, Mcp-Session-Id',
+  'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
 };
 
 /**
  * Basic CORS headers for simple responses
  */
 export const BASIC_CORS_HEADERS = {
-  'Access-Control-Allow-Origin': '*'
+  'Access-Control-Allow-Origin': '*',
 };
 
 /**
@@ -27,7 +28,7 @@ export const BASIC_CORS_HEADERS = {
 export function withCORS(additionalHeaders = {}) {
   return {
     ...CORS_HEADERS,
-    ...additionalHeaders
+    ...additionalHeaders,
   };
 }
 
@@ -37,6 +38,6 @@ export function withCORS(additionalHeaders = {}) {
 export function withBasicCORS(additionalHeaders = {}) {
   return {
     ...BASIC_CORS_HEADERS,
-    ...additionalHeaders
+    ...additionalHeaders,
   };
 }

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -1,14 +1,12 @@
 /**
  * @aws-lambda-mcp/adapter
- * 
+ *
  * An MCP (Model Context Protocol) server SDK for AWS Lambda
  * with Zod-based type safety, authentication support, and clean separation of concerns.
  */
 
 // Core imports
 import { MCPServer } from './mcp-server.mjs';
-import { createLambdaHandler } from './lambda-adapter.mjs';
-import { CommonSchemas } from './common-schemas.mjs';
 
 // Core exports
 export { MCPServer } from './mcp-server.mjs';

--- a/src/lambda-adapter.mjs
+++ b/src/lambda-adapter.mjs
@@ -1,6 +1,6 @@
 /**
  * AWS Lambda Adapter
- * 
+ *
  * Handles Lambda integration and HTTP request/response processing
  */
 
@@ -14,21 +14,31 @@ export function createResponse(body, statusCode = 200, headers = {}) {
     statusCode,
     headers: {
       'Content-Type': 'application/json',
-      ...headers
+      ...headers,
     },
-    body: typeof body === 'string' ? body : JSON.stringify(body)
+    body: typeof body === 'string' ? body : JSON.stringify(body),
   };
 }
 
 /**
  * Create error response
  */
-export function createErrorResponse(statusCode, code, message, headers = {}, id = null) {
-  return createResponse({
-    jsonrpc: '2.0',
-    error: { code, message },
-    id
-  }, statusCode, headers);
+export function createErrorResponse(
+  statusCode,
+  code,
+  message,
+  headers = {},
+  id = null
+) {
+  return createResponse(
+    {
+      jsonrpc: '2.0',
+      error: { code, message },
+      id,
+    },
+    statusCode,
+    headers
+  );
 }
 
 /**
@@ -37,50 +47,84 @@ export function createErrorResponse(statusCode, code, message, headers = {}, id 
 export async function handleMCPRequest(mcpServer, body, headers, corsHeaders) {
   const contentType = headers['content-type'] || headers['Content-Type'] || '';
   if (!contentType.includes('application/json')) {
-    return createErrorResponse(400, -32700, 'Parse error: Content-Type must be application/json', corsHeaders);
+    return createErrorResponse(
+      400,
+      -32700,
+      'Parse error: Content-Type must be application/json',
+      corsHeaders
+    );
   }
-  
+
   let jsonRpcMessage;
   try {
     jsonRpcMessage = JSON.parse(body || '{}');
-  } catch (error) {
-    return createErrorResponse(400, -32700, 'Parse error: Invalid JSON', corsHeaders);
+  } catch {
+    return createErrorResponse(
+      400,
+      -32700,
+      'Parse error: Invalid JSON',
+      corsHeaders
+    );
   }
-  
+
   if (!jsonRpcMessage.jsonrpc || jsonRpcMessage.jsonrpc !== '2.0') {
-    return createErrorResponse(400, -32600, 'Invalid Request: missing jsonrpc field', corsHeaders, jsonRpcMessage.id);
+    return createErrorResponse(
+      400,
+      -32600,
+      'Invalid Request: missing jsonrpc field',
+      corsHeaders,
+      jsonRpcMessage.id
+    );
   }
-  
+
   if (!jsonRpcMessage.method) {
-    return createErrorResponse(400, -32600, 'Invalid Request: missing method field', corsHeaders, jsonRpcMessage.id);
+    return createErrorResponse(
+      400,
+      -32600,
+      'Invalid Request: missing method field',
+      corsHeaders,
+      jsonRpcMessage.id
+    );
   }
-  
+
   try {
     const result = await mcpServer.handleRequest(jsonRpcMessage);
-    
+
     if (result === null) {
       return createResponse('', 204, corsHeaders);
     }
-    
-    return createResponse({
-      jsonrpc: '2.0',
-      result,
-      id: jsonRpcMessage.id
-    }, 200, corsHeaders);
-    
+
+    return createResponse(
+      {
+        jsonrpc: '2.0',
+        result,
+        id: jsonRpcMessage.id,
+      },
+      200,
+      corsHeaders
+    );
   } catch (error) {
     console.error('MCP request error:', error);
-    
+
     let errorCode = -32603; // Internal error
     let errorMessage = error.message;
-    
+
     if (error.message.includes('Method not found')) {
       errorCode = -32601;
-    } else if (error.message.includes('not found') || error.message.includes('required')) {
+    } else if (
+      error.message.includes('not found') ||
+      error.message.includes('required')
+    ) {
       errorCode = -32602; // Invalid params
     }
-    
-    return createErrorResponse(500, errorCode, errorMessage, corsHeaders, jsonRpcMessage.id);
+
+    return createErrorResponse(
+      500,
+      errorCode,
+      errorMessage,
+      corsHeaders,
+      jsonRpcMessage.id
+    );
   }
 }
 
@@ -88,39 +132,61 @@ export async function handleMCPRequest(mcpServer, body, headers, corsHeaders) {
  * AWS Lambda Adapter for MCP Server
  */
 export function createLambdaHandler(mcpServer, options = {}) {
-  const baseHandler = async (event, context) => {
+  const baseHandler = async (event) => {
     try {
       const method = event.httpMethod || event.requestContext?.http?.method;
       const headers = event.headers || {};
-      
+
       if (method === 'OPTIONS') {
         return createResponse('', 200, CORS_HEADERS);
       }
-      
+
       if (method === 'POST') {
-        return await handleMCPRequest(mcpServer, event.body, headers, CORS_HEADERS);
+        return await handleMCPRequest(
+          mcpServer,
+          event.body,
+          headers,
+          CORS_HEADERS
+        );
       }
-      
+
       if (method === 'GET') {
-        return createErrorResponse(405, -32000, 'Method not allowed: Stateless mode', CORS_HEADERS);
+        return createErrorResponse(
+          405,
+          -32000,
+          'Method not allowed: Stateless mode',
+          CORS_HEADERS
+        );
       }
-      
-      return createErrorResponse(405, -32000, `Method not allowed: ${method}`, CORS_HEADERS);
-      
+
+      return createErrorResponse(
+        405,
+        -32000,
+        `Method not allowed: ${method}`,
+        CORS_HEADERS
+      );
     } catch (error) {
       console.error('Lambda error:', error);
-      return createErrorResponse(500, -32603, 'Internal server error', 
+      return createErrorResponse(
+        500,
+        -32603,
+        'Internal server error',
         withBasicCORS({ 'Content-Type': 'application/json' })
       );
     }
   };
-  
+
   // If authentication is configured, wrap with authentication middleware
   if (options.auth) {
     return async (event, context) => {
       try {
-        const { createAuthenticatedHandler } = await import('./auth/middleware.mjs');
-        const authenticatedHandler = createAuthenticatedHandler(baseHandler, options.auth);
+        const { createAuthenticatedHandler } = await import(
+          './auth/middleware.mjs'
+        );
+        const authenticatedHandler = createAuthenticatedHandler(
+          baseHandler,
+          options.auth
+        );
         return await authenticatedHandler(event, context);
       } catch (error) {
         console.error('Authentication module error:', error);
@@ -129,12 +195,12 @@ export function createLambdaHandler(mcpServer, options = {}) {
           headers: withBasicCORS({ 'Content-Type': 'application/json' }),
           body: JSON.stringify({
             error: 'server_error',
-            message: 'Authentication module not available'
-          })
+            message: 'Authentication module not available',
+          }),
         };
       }
     };
   }
-  
+
   return baseHandler;
 }


### PR DESCRIPTION
- Add ESLint v9 with TypeScript support using flat config
- Add Prettier for consistent code formatting
- Remove unused variables and imports
- Improve type safety by replacing 'any' types with more specific types:
  - AuthUser: any → unknown
  - ToolHandler/PromptHandler: any → Record<string, unknown>
  - handleRequest: any → JsonRpcRequest/JsonRpcResponse
- Add JSON-RPC type definitions
- Add lint and format npm scripts
- All tests passing (16/16)
- Zero ESLint errors